### PR TITLE
Expose some more reqwest rustls features

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,3 +27,6 @@ tokio = { version = "1", features = ["rt", "macros"] }
 default = ["reqwest/default"]
 native-tls = ["reqwest/native-tls"]
 rustls-tls = ["reqwest/rustls-tls"]
+rustls-tls-manual-roots = ["reqwest/rustls-tls-manual-roots"]
+rustls-tls-native-roots = ["reqwest/rustls-tls-native-roots"]
+rustls-tls-webpki-roots = ["reqwest/rustls-tls-webpki-roots"]


### PR DESCRIPTION
This exposes the following features from the reqwest dependency:
- rustls-tls-manual-roots
- rustls-tls-native-roots
- rustls-tls-webpki-roots

That allows users of this crate to select in greater detail which certificate verification mechanism from the rustls crate they want to use.