### PR TITLE
fix: Error Message

### DIFF
--- a/src/types.rs
+++ b/src/types.rs
@@ -243,7 +243,19 @@ pub mod common {
                 Ok(self)
             } else {
                 let text = self.text().await?;
-                let tmp: DavErrorTmp = serde_xml_rs::from_str(&text)?;
+                let tmp: DavErrorTmp = match serde_xml_rs::from_str(&text) {
+                    Ok(tmp) => tmp,
+                    Err(_) => {
+                        return Err(error(
+                            Kind::Dav,
+                            DavError {
+                                status_code: code,
+                                exception: "unknown".to_string(),
+                                message: text,
+                            },
+                        ))
+                    }
+                };
                 Err(error(
                     Kind::Dav,
                     DavError {


### PR DESCRIPTION
某些情况下会返回类似这样的信息，xml解析出错后直接报错 `Unexpected closing tag: body != hr` 无法得到准确的信息。

```html
<html>
<head><title>413 Request Entity Too Large</title></head>
<body>
<center><h1>413 Request Entity Too Large</h1></center>
<hr><center>nginx/1.22.1</center>
</body>
</html>
```