### PR TITLE
Implementing copy endpoint

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,7 @@ An async webdav client for rust with tokio and reqwest
   - [x] Get
   - [x] Put
   - [x] Mv
+  - [x] Cp
   - [x] Delete
   - [x] Mkcol
   - [x] List


### PR DESCRIPTION
I found this for documentation on the webdav protocol and implemented it based on the `mv` command:

https://learn.microsoft.com/en-us/previous-versions/office/developer/exchange-server-2003/aa142816(v=exchg.65)