### PR TITLE
Handle empty last modified

### DIFF
--- a/src/types/list_cmd.rs
+++ b/src/types/list_cmd.rs
@@ -156,7 +156,10 @@ where
         Some(value) if value.is_empty() => Ok(None),
         Some(value) => match httpdate::parse_http_date(&value) {
             Ok(system_time) => Ok(Some(DateTime::<Utc>::from(system_time))),
-            Err(_) => Err(serde::de::Error::custom("parse error")),
+            Err(_) => Err(serde::de::Error::invalid_value(
+                serde::de::Unexpected::Str(&value),
+                &"a valid HTTP date",
+            )),
         },
     }
 }
@@ -172,7 +175,10 @@ where
         Some(value) if value.is_empty() => Ok(None),
         Some(value) => match value.parse::<i64>() {
             Ok(number) => Ok(Some(number)),
-            Err(_) => Err(serde::de::Error::custom("parse error")),
+            Err(_) => Err(serde::de::Error::invalid_value(
+                serde::de::Unexpected::Str(&value),
+                &"a valid number",
+            )),
         },
     }
 }


### PR DESCRIPTION
I don't know if this is valid webdav or if this is actually a problem with the server I'm dealing with (which is outside of my control), but I had a case where the `getlastmodified` field was just an empty string, which caused the parsing to fail. Since the last modified is optional (at
least in the `ListProp`), I think it's fine to handle empty strings the same as if the whole prop is missing (the same as it's also in `empty_number`).

I also improved the errors for these custom parsers a little to not just show "parse error", which confused me a lot when trying to figure out what is causing this to fail. So it now shows the original content of the value that failed to parse and a little text of what would have been expected.