### PR TITLE
Update reqwest to 0.13

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,7 +11,7 @@ resolver = "2"
 
 [dependencies]
 digest_auth = "0.3"
-reqwest = { version = "0.12", default-features = false }
+reqwest = { version = "0.13", default-features = false, features = ["form"] }
 url = "2.3"
 tokio = { version = "1", features = ["sync"] }
 http = "1.0"
@@ -30,7 +30,4 @@ wiremock = "0.6"
 [features]
 default = ["reqwest/default"]
 native-tls = ["reqwest/native-tls"]
-rustls-tls = ["reqwest/rustls-tls"]
-rustls-tls-manual-roots = ["reqwest/rustls-tls-manual-roots"]
-rustls-tls-native-roots = ["reqwest/rustls-tls-native-roots"]
-rustls-tls-webpki-roots = ["reqwest/rustls-tls-webpki-roots"]
+rustls-tls = ["reqwest/rustls"]


### PR DESCRIPTION
This is a breaking change: the roots features don't exist anymore. Reqwest now uses `rustls-platform-verifier` by default, which just uses the operating systems CAs. If people want to use different roots, they need to call `tls_certs_only(your_roots)`.

Also reqwest now switched to use rustls by default (which also means it's the new default for this crate).

Reqwest also renamed the `rustls-tls` feature to `rustls`, I wasn't sure if I should do the same for this crate. For now I left it as is, but let me know if you also want me to change it (as there are breaking changes already).