### PR TITLE
Add content-type header for PROPFIND method

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -217,6 +217,10 @@ impl Client {
                         Depth::Infinity => "infinity".to_owned(),
                     })?,
                 );
+                map.insert(
+                    "content-type",
+                    HeaderValue::from_str("text/xml; charset=\"utf-8\"")?,
+                );
                 map
             })
             .body(body)


### PR DESCRIPTION
fn list_raw does not set content-type, this leads 403 error on server that use strict modsecurity rules. see also: https://github.com/coreruleset/coreruleset/blob/62fa7fc47638a9730416b774c892c56507fdf2f8/rules/REQUEST-920-PROTOCOL-ENFORCEMENT.conf#L689-L711